### PR TITLE
Fix snarfing not completing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "node-fetch": "^2.6.1",
         "node-html-parser": "^4.1.3",
         "stream-buffers": "^3.0.2",
-        "unzipper": "^0.10.10"
+        "unzipper": "^0.10.14"
       },
       "devDependencies": {
         "@types/archiver": "^5.1.1",
@@ -2110,9 +2110,9 @@
       }
     },
     "node_modules/unzipper": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-      "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
       "dependencies": {
         "big-integer": "^1.6.17",
         "binary": "~0.3.0",
@@ -3923,9 +3923,9 @@
       }
     },
     "unzipper": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-      "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
       "requires": {
         "big-integer": "^1.6.17",
         "binary": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "node-fetch": "^2.6.1",
     "node-html-parser": "^4.1.3",
     "stream-buffers": "^3.0.2",
-    "unzipper": "^0.10.10"
+    "unzipper": "^0.10.14"
   },
   "prettier": {
     "printWidth": 120

--- a/src/snarfBrowser.ts
+++ b/src/snarfBrowser.ts
@@ -105,7 +105,7 @@ export const snarfItem = (item: AsyncItem) => {
     }
 
     try {
-      await zip.extract({ path: unzipPath});
+      await zip.extract({ path: unzipPath });
     } catch (err) {
       // @ts-ignore
       window.showErrorMessage(`An error occurred: ${err?.message}`);

--- a/src/snarfBrowser.ts
+++ b/src/snarfBrowser.ts
@@ -104,7 +104,14 @@ export const snarfItem = (item: AsyncItem) => {
       if (ans !== "Yes") return;
     }
 
-    await zip.extract({ path: unzipPath, concurrency: 5 });
+    try {
+      await zip.extract({ path: unzipPath});
+    } catch (err) {
+      // @ts-ignore
+      window.showErrorMessage(`An error occurred: ${err?.message}`);
+      console.error(err);
+      return;
+    }
 
     try {
       await commands.executeCommand("java.project.import");


### PR DESCRIPTION
When snarfing a lab, people would sometimes run into an issue where the extension would only create the folder and add one file, then seemingly stop. This issue happened specifically with Google Drive and the extension threw an error in the logs at the unzip.extract() part, for example: 
`[error] Error: EEXIST: file already exists, mkdir 'g:\My Drive\Testing\JMCh09_SnackBar'`
Deleting the concurrency parameter in the zip.extract() line seems to fix this issue. 